### PR TITLE
CMS-98: Support returning info about created PR and optionally add comment to PR being closed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: php vendor/bin/php-coveralls -v
+        run: php vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
 
   build_phar:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         dependencies: ['lock']
         include:
           - php-versions: 7.4
-            dependencies: hightest
+            dependencies: highest
             operating-system: 'ubuntu-latest'
     env:
       SCENARIO: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       SCENARIO: default
       DEPENDENCIES: ${{ matrix.dependencies }}
-    needs: [ checkout_build ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ on: push
 jobs:
   test:
     runs-on: ${{ matrix.operating-system }}
-    name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }} (${{ matrix.dependencies }})
+    name: Functional testing matrix - PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }} (${{ matrix.dependencies }})
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
         dependencies: ['lock']
         include:
-          - php-versions: 7.4
+          - php-version: 7.4
             dependencies: highest
             operating-system: 'ubuntu-latest'
     env:
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
       # @todo cache?
       - name: Install dependencies
         run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"
       - name: Run tests
         run: composer test
-      - name: Run coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: php vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
+      #- name: Run coveralls
+      #  env:
+      #    COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  run: php vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
 
   build_phar:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: Hubh
+on: push
+jobs:
+  test:
+    runs-on: ${{ matrix.operating-system }}
+    name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }} (${{ matrix.dependencies }})
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest', 'macos-latest']
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        dependencies: ['highest', 'lowest', 'lock']
+    env:
+      SCENARIO: default
+      DEPENDENCIES: ${{ matrix.dependencies }}
+    needs: [ checkout_build ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # @todo cache?
+      - name: Install dependencies
+        run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"
+      - name: Run tests
+        run: composer test
+      - name: Run coveralls
+        run: php vendor/bin/php-coveralls -v
+
+  build_phar:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pantheon-public/php-ci:v7.4
+    needs: [ test ]
+    name: Checkout & build Phar
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Save repo content as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: full-workspace
+          path: ${{ github.workspace }}
+      - name: Install tools
+        run: composer phar:install-tools
+      - name: Run Composer Install
+        run: composer install --prefer-dist --no-dev --no-interaction
+      - name: Phar Build
+        run: php box.phar build
+      - name: permissions
+        run: chmod +x ./hubph.phar
+      - name: Save hubph.phar as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: hubph-phar
+          path: hubph.phar
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    container:
+      image: quay.io/pantheon-public/php-ci:v7.4
+    needs: [ build_phar ]
+    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'g1a/hubph' }}
+    steps:
+      - name: Download hubph.phar as artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: hubph-phar
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: hubph.phar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
+        # @todo: Add 8.1 coverage.
+        php-version: [ '7.3', '7.4', '8.0']
         dependencies: ['lock']
         include:
           - php-version: 7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,22 @@ jobs:
         run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"
       - name: Run tests
         run: composer test
-      - name: Run coveralls
-        run: php vendor/bin/php-coveralls -v
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.operating-system }}-${{ matrix.php-version }}-${{ matrix.dependencies }}
+          parallel: true
+
+  coveralls_finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true
 
   build_phar:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ jobs:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
         php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
-        dependencies: ['highest', 'lowest', 'lock']
+        dependencies: ['lock']
+        include:
+          - php-versions: 7.4
+            dependencies: hightest
+            operating-system: 'ubuntu-latest'
     env:
       SCENARIO: default
       DEPENDENCIES: ${{ matrix.dependencies }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        # @todo: Add 8.1 coverage.
-        php-version: [ '7.3', '7.4', '8.0']
+        # @todo: Add 8.1 & 8.0 coverage.
+        php-version: [ '7.3', '7.4']
         dependencies: ['lock']
         include:
           - php-version: 7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,16 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug
-      # @todo cache?
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
       - name: Install dependencies
         run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"
       - name: Run tests
@@ -49,6 +58,16 @@ jobs:
         with:
           name: full-workspace
           path: ${{ github.workspace }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
       - name: Install tools
         run: composer phar:install-tools
       - name: Run Composer Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,22 +29,10 @@ jobs:
         run: composer scenario "${SCENARIO}" "${DEPENDENCIES}"
       - name: Run tests
         run: composer test
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.operating-system }}-${{ matrix.php-version }}-${{ matrix.dependencies }}
-          parallel: true
-
-  coveralls_finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
+      - name: Run coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: php vendor/bin/php-coveralls -v
 
   build_phar:
     runs-on: ubuntu-latest

--- a/src/HubphAPI.php
+++ b/src/HubphAPI.php
@@ -86,7 +86,7 @@ class HubphAPI
 
     public function prCreate($org, $project, $title, $body, $base, $head)
     {
-        $this->prOpen($org, $project, $title, $body, $base, $head);
+        $response = $this->prOpen($org, $project, $title, $body, $base, $head);
         $this->logEvent(__FUNCTION__, [$org, $project], $params, $response);
         return $this;
     }

--- a/src/HubphAPI.php
+++ b/src/HubphAPI.php
@@ -73,7 +73,7 @@ class HubphAPI
         return $this->gitHubAPI()->api('pull_request')->show($org, $project, $id);
     }
 
-    public function prCreate($org, $project, $title, $body, $base, $head, &$response = null)
+    public function prOpen($org, $project, $title, $body, $base, $head)
     {
         $params = [
             'title' => $title,
@@ -81,7 +81,12 @@ class HubphAPI
             'base' => $base,
             'head' => $head,
         ];
-        $response = $this->gitHubAPI()->api('pull_request')->create($org, $project, $params);
+        return $this->gitHubAPI()->api('pull_request')->create($org, $project, $params);
+    }
+
+    public function prCreate($org, $project, $title, $body, $base, $head)
+    {
+        $this->prOpen($org, $project, $title, $body, $base, $head);
         $this->logEvent(__FUNCTION__, [$org, $project], $params, $response);
         return $this;
     }

--- a/src/HubphAPI.php
+++ b/src/HubphAPI.php
@@ -86,10 +86,15 @@ class HubphAPI
         return $this;
     }
 
-    public function prClose($org, $project, PullRequests $prs)
+    public function prClose($org, $project, PullRequests $prs, $comment = '')
     {
         foreach ($prs->prNumbers() as $n) {
             $gitHubAPI = $this->gitHubAPI();
+            if ($comment) {
+                $gitHubAPI->api('issue')->comments()->create($org, $project, $n, [
+                    'body' => $comment,
+                ]);
+            }
             $gitHubAPI->api('pull_request')->update($org, $project, $n, ['state' => 'closed']);
         }
     }

--- a/src/HubphAPI.php
+++ b/src/HubphAPI.php
@@ -73,7 +73,7 @@ class HubphAPI
         return $this->gitHubAPI()->api('pull_request')->show($org, $project, $id);
     }
 
-    public function prCreate($org, $project, $title, $body, $base, $head)
+    public function prCreate($org, $project, $title, $body, $base, $head, &$response = null)
     {
         $params = [
             'title' => $title,


### PR DESCRIPTION
### Overview
This pull request supports returning information about the created PR and adds option to add comment to the PR being closed.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Description
- prCreate function now receives a new optional argument $response that will be filled with the response info after creating the PR.
- prClose function now receives a new optional argument $comment that will be posted to the PR just before closing it.
