### PR TITLE
[CMS-98] Move logEvent call to prOpen function.

### DIFF
--- a/src/HubphAPI.php
+++ b/src/HubphAPI.php
@@ -81,13 +81,14 @@ class HubphAPI
             'base' => $base,
             'head' => $head,
         ];
-        return $this->gitHubAPI()->api('pull_request')->create($org, $project, $params);
+        $response = $this->gitHubAPI()->api('pull_request')->create($org, $project, $params);
+        $this->logEvent(__FUNCTION__, [$org, $project], $params, $response);
+        return $response;
     }
 
     public function prCreate($org, $project, $title, $body, $base, $head)
     {
-        $response = $this->prOpen($org, $project, $title, $body, $base, $head);
-        $this->logEvent(__FUNCTION__, [$org, $project], $params, $response);
+        $this->prOpen($org, $project, $title, $body, $base, $head);
         return $this;
     }
 


### PR DESCRIPTION
### Overview
This pull request moves logEvent call to prOpen function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Moves to logEvent call to prOpen function.

### Description
Doing this we allow tools depending on this tool to call either prOpen or prCreate and get logging.